### PR TITLE
Fix import statement in lispify

### DIFF
--- a/lispify/lispify.py
+++ b/lispify/lispify.py
@@ -12,7 +12,7 @@ so that the lispify method ignores it.
 from numbers import Number
 import warnings
 
-from .util import subclasses, camel_case_to_lisp_name
+from util import subclasses, camel_case_to_lisp_name
 
 
 # For fully deterministic lisp types use this priority.


### PR DESCRIPTION
I was getting import errros when using lispify in Wikipediabase. I believe the cause was python looking at the wrong util.py because `.util` makes python use the local file (maybe). Even if this is not the cause of the issues I was getting, it's a harmless change.
