### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# [Changelog](https://github.com/infolab-csail/lispify/releases)
+
+## 1.0.0 (2016-06-25)
+
+Initial copy over from [WikipediaBase](https://github.com/infolab-csail/WikipediaBase).
+
+For previous commit history, see https://github.com/infolab-csail/WikipediaBase/commit/cf697dddc1a071ae0dd9a8484254a3295d32d1c0 and earlier.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# lispify
+# Lispify [![Build Status](https://travis-ci.org/infolab-csail/lispify.svg?branch=master)](https://travis-ci.org/infolab-csail/lispify) [![codecov](https://codecov.io/gh/infolab-csail/lispify/branch/master/graph/badge.svg)](https://codecov.io/gh/infolab-csail/lispify)
 Lispify converts Python objects into Lisp-like encoded strings that are interpretable in Common Lisp.
+
+## Releases
+
+Each release should be documented in CHANGELOG.md.
+
+Version numbers `MAJOR.MINOR.PATCH` should follow a system inspired by [semantic versioning](http://semver.org/). Increment the:
+
+1. MAJOR version when you make incompatible API changes (unlikely to change from `1.x.x`),
+1. MINOR version when you add functionality in a backwards-compatible manner, and
+1. PATCH version when you make backwards-compatible bug fixes.
+
+Create a [release](https://help.github.com/articles/creating-releases/) on Github for each new version.


### PR DESCRIPTION
I should have done this earlier (sorry). We should follow the same protocol for updating the version number as with WikipediaBase. 

Given we have some important changes coming along (https://github.com/infolab-csail/lispify/pull/5), we should have a place to record them when we bump the version.
