### PR TITLE
Add missing dependencies to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.5-dev"
   - "nightly"
 install:
-  - pip install -r requirements.txt
+  - if [[ $TRAVIS_INSTALL_LIKE_PIP == false ]]; then pip install -r requirements.txt; fi
   - pip install codecov pep8
   - python setup.py install
 script:
@@ -16,3 +16,6 @@ script:
   - pep8 lispify tests --ignore=E501
 after_success:
   - codecov
+env:
+    - TRAVIS_INSTALL_LIKE_PIP=true
+    - TRAVIS_INSTALL_LIKE_PIP=false

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ setup(
         'lispify',
         'tests',
     ],
+    install_requires=[
+        'future',
+    ],
     tests_require=[
         'nose>=1.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'future',
     ],
     tests_require=[
+        'unittest2',
         'nose>=1.0',
     ],
     test_suite='nose.collector',


### PR DESCRIPTION
In #5 our `requirements.txt` and `setup.py` dependencies diverged, which resulted in [failing WikipediaBase builds](https://travis-ci.org/infolab-csail/WikipediaBase/jobs/149193217). This PR adjusts Travis to detect this issue, and then addresses the issue by adding the missing dependencies.

For more details on the usage of `requirements.txt` vs. `setup.py`, see the commit message in 86976a0.
