### PR TITLE
Update camelcase function in util.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 install:
   - if [[ $TRAVIS_INSTALL_LIKE_PIP == false ]]; then pip install -r requirements.txt; fi
   - pip install codecov pep8
+  - pip install setuptools
   - python setup.py install
 script:
   - coverage run setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 install:
   - if [[ $TRAVIS_INSTALL_LIKE_PIP == false ]]; then pip install -r requirements.txt; fi
   - pip install codecov pep8
-  - pip install setuptools==39.2.0
+  - pip install setuptools==36.8.0
   - python setup.py install
 script:
   - coverage run setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 install:
   - if [[ $TRAVIS_INSTALL_LIKE_PIP == false ]]; then pip install -r requirements.txt; fi
   - pip install codecov pep8
-  - pip install --upgrade setuptools
+  - pip install setuptools==39.2.0
   - python setup.py install
 script:
   - coverage run setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: python
+# we test python 2.7 because it is what we use, we test python 3.4
+# because it is the version of python3 that we have installed, and
+# we test the nightly build to make sure we are all up-to-date
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
-  - "3.5"
-  - "3.5-dev"
   - "nightly"
 install:
   - if [[ $TRAVIS_INSTALL_LIKE_PIP == false ]]; then pip install -r requirements.txt; fi
   - pip install codecov pep8
-  - pip install setuptools==36.8.0
+  - pip install --upgrade setuptools
   - python setup.py install
 script:
   - coverage run setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 install:
   - if [[ $TRAVIS_INSTALL_LIKE_PIP == false ]]; then pip install -r requirements.txt; fi
   - pip install codecov pep8
-  - pip install setuptools
+  - pip install --upgrade setuptools
   - python setup.py install
 script:
   - coverage run setup.py test

--- a/lispify/util.py
+++ b/lispify/util.py
@@ -26,4 +26,3 @@ def camel_case_to_lisp_name(text):
     """
     s = re.sub('(.)([A-Z][a-z]+)', r'\1-\2', text)
     return re.sub('([a-z0-9])([A-Z])', r'\1-\2', s).lower()
-

--- a/lispify/util.py
+++ b/lispify/util.py
@@ -19,10 +19,11 @@ def subclasses(cls):
             if not C.__name__.startswith("_")]
 
 
-def camel_case_to_lisp_name(name):
+def camel_case_to_lisp_name(text):
     """
-    Convert a python CamelCase class name to lisp hyphenated class name.
+    Converts CamelCase text to standard lisp hyphenated text
+    e.g., "educationalInstitution" -> "educational-institution"
     """
-    words = map(lambda s: s.lower(), re.findall('[A-Z][a-z]*', name))
-    lisp_name = '-'.join(words)
-    return lisp_name
+    s = re.sub('(.)([A-Z][a-z]+)', r'\1-\2', text)
+    return re.sub('([a-z0-9])([A-Z])', r'\1-\2', s).lower()
+


### PR DESCRIPTION
Back when some of the same code existed in both WikipediaBase and lispify, changes were made to the `camel_case_to_lisp_name` function in WikipediaBase that were not carried over to the version in lispify. 

According to the git blame of the `util.py` file in WikipediaBase, the change was because the old version was not working in all cases. 